### PR TITLE
Rename project to avoid mac-template-directory issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Underscore.template
+# Underscore-template
 
 More APIs for Underscore's template engine - template fetching, rendering and caching.
 
 ## Install
 
 ```bash
-$ bower install underscore.template
+$ bower install underscore-template
 ```
 
 ***

--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
-  "name": "underscore.template",
-  "version": "0.1.0",
-  "homepage": "https://github.com/cssmagic/underscore.template",
+  "name": "underscore-template",
+  "version": "0.1.1",
+  "homepage": "https://github.com/cssmagic/underscore-template",
   "authors": [
     "cssmagic"
   ],
   "description": "More APIs for Underscore's template engine.",
-  "main": "src/action.js",
+  "main": "src/underscore-template.js",
   "moduleType": [
     "globals"
   ],

--- a/src/underscore-template.js
+++ b/src/underscore-template.js
@@ -1,7 +1,7 @@
 /**
- * Underscore.template - More APIs for Underscore's template engine - template fetching, rendering and caching.
+ * Underscore-template - More APIs for Underscore's template engine - template fetching, rendering and caching.
  * Released under the MIT license.
- * https://github.com/cssmagic/underscore.template
+ * https://github.com/cssmagic/underscore-template
  */
 var template = function () {
 	'use strict'

--- a/test/test.html
+++ b/test/test.html
@@ -2,15 +2,15 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>UT - Underscore.template</title>
+<title>UT - Underscore-template</title>
 <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
 <link rel="stylesheet" href="../bower_components/mocha/mocha.css">
 <link rel="stylesheet" href="../bower_components/mocha.css/src/mocha.css">
 </head>
 <body>
 <header>
-	<h1>UT - Underscore.template</h1>
-	<p><a href="https://github.com/cssmagic/underscore.template">View on GitHub</a></p>
+	<h1>UT - Underscore-template</h1>
+	<p><a href="https://github.com/cssmagic/underscore-template">View on GitHub</a></p>
 </header>
 <div id="mocha"></div>
 <!-- deps -->
@@ -26,7 +26,7 @@ mocha.checkLeaks()
 var expect = chai.expect
 </script>
 <!-- source code -->
-<script src="../src/underscore.template.js"></script>
+<script src="../src/underscore-template.js"></script>
 <!-- test-case -->
 <script src="test.js"></script>
 <!-- init -->


### PR DESCRIPTION
在 Mac 下，如果一个目录名是以 `.template` 结尾的，则会被识别为一个包（类似于 `*.app`），无法正常访问其内部的文件。因此，把这个项目改名以避免此问题。

在 Bower 注册的包也注销并重新注册了。
