### PR TITLE
对_toTemplateId进行参数检测，并对部分函数进行优化

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,6 @@
     "demo"
   ],
   "dependencies": {
-    "underscore.string": "2.*",
     "underscore": "1.*"
   },
   "devDependencies": {

--- a/src/underscore-template.js
+++ b/src/underscore-template.js
@@ -20,14 +20,14 @@ var template = function () {
 	function _trim(str) {
 		return str.replace(/^\s*|\s*$/g, '')
 	}
-	function _include(str, key) {
-		return str.indexOf(key) > -1
+	function _include(str, substring) {
+		return str.length > substring.length ? str.indexOf(substring) > -1 : false
 	}
-	function _startsWith(str, key) {
-		return str.indexOf(key) === 0
+	function _startsWith(str, starts) {
+		return str.length > starts.length ? str.indexOf(starts) === 0 : false
 	}
-	function _endsWith(str, key) {
-		return str.indexOf(key) === (str.length - key.length)
+	function _endsWith(str, ends) {
+		return str.length > ends.length ? str.indexOf(ends) === (str.length - ends.length) : false
 	}
 
 	//util

--- a/src/underscore-template.js
+++ b/src/underscore-template.js
@@ -18,7 +18,7 @@ var template = function () {
 
 	//string function
 	function _trim(str) {
-		return str.replace(/^\s*|\s*$/g, '')
+		return str.replace(/^\s+|\s+$/g, '')
 	}
 	function _include(str, substring) {
 		return str.length > substring.length ? str.indexOf(substring) > -1 : false

--- a/src/underscore-template.js
+++ b/src/underscore-template.js
@@ -17,17 +17,17 @@ var template = function () {
 	var _cacheCompiledTemplate = {}
 
 	//string function
-	function trim(str) {
+	function _trim(str) {
 		return str.replace(/^\s*|\s*$/g, '')
 	}
-	function include(str, key) {
+	function _include(str, key) {
 		return str.indexOf(key) > -1
 	}
-	function startsWith(str, key) {
-		return str.substr(0, key.length) === key
+	function _startsWith(str, key) {
+		return str.indexOf(key) === 0
 	}
-	function endsWith(str, key) {
-		return str.substr(str.length - key.length, key.length) === key
+	function _endsWith(str, key) {
+		return str.indexOf(key) === (str.length - key.length)
 	}
 
 	//util
@@ -35,20 +35,20 @@ var template = function () {
 		//`#template-my-tpl-001` -> `my-tpl-001`
 		// `template-my-tpl-001` -> `my-tpl-001`
 		//          `my-tpl-001` -> `my-tpl-001`
-		id = id ? trim(id).replace(/^[#!]+/, '') : ''
-		return trim(id).replace(ELEM_ID_PREFIX, '')
+		id = _.isString(id) && id ? _trim(id).replace(/^[#!]+/, '') : ''
+		return _trim(id).replace(ELEM_ID_PREFIX, '')
 	}
 	function _toElementId(id) {
 		//`template-my-tpl-001` -> `template-my-tpl-001`
 		//         `my-tpl-001` -> `template-my-tpl-001`
-		id = id ? trim(id) : ''
-		return startsWith(id, ELEM_ID_PREFIX) ? id : ELEM_ID_PREFIX + id
+		id = id ? _trim(id) : ''
+		return _startsWith(id, ELEM_ID_PREFIX) ? id : ELEM_ID_PREFIX + id
 	}
 	function _stripCommentTag(str) {
 		str = String(str)
-		if (startsWith(str, '<!' + '--') && endsWith(str, '-->')) {
+		if (_startsWith(str, '<!' + '--') && _endsWith(str, '-->')) {
 			str = str.replace(/^<!\-\-/, '').replace(/\-\->$/, '')
-			str = trim(str)
+			str = _trim(str)
 		}
 		return str
 	}
@@ -59,7 +59,7 @@ var template = function () {
 		var elementId = _toElementId(String(id))
 		var elem = document.getElementById(elementId)
 		if (elem) {
-			var str = trim(elem.innerHTML)
+			var str = _trim(elem.innerHTML)
 			if (str) {
 				//strip html comment tag wrapping template code
 				//especially for jedi 1.0 (https://github.com/baixing/jedi)
@@ -86,7 +86,7 @@ var template = function () {
 	}
 	function _isTemplateCode(s) {
 		var code = String(s)
-		return include(code, '<%') && include(code, '%>') && /\bdata\b/.test(code)
+		return _include(code, '<%') && _include(code, '%>') && /\bdata\b/.test(code)
 	}
 
 	//fn

--- a/test/test.js
+++ b/test/test.js
@@ -177,6 +177,11 @@ void function () {
 		var data, html1, html2
 		var _cacheTemplate, _cacheCompiledTemplate
 
+		//string
+		function clean(str) {
+			return str.replace(/^\s*|\s*$/g, '').replace(/\s+/g, ' ')
+		}
+
 		//util
 		function clearCodeCache() {
 			delete _cacheTemplate[TEMPLATE_ID_1]
@@ -265,8 +270,8 @@ void function () {
 				html1 = template.render(TEMPLATE_ID_1, templateData1)
 				expect(html1).to.equal(result1)
 				html2 = template.render(TEMPLATE_ID_2, templateData2)
-				html2 = _.str.clean(html2)
-				result2 = _.str.clean(result2)
+				html2 = clean(html2)
+				result2 = clean(result2)
 				expect(html2).to.equal(result2)
 
 				//check if template code saved to cache

--- a/test/test.js
+++ b/test/test.js
@@ -179,7 +179,7 @@ void function () {
 
 		//string
 		function clean(str) {
-			return str.replace(/^\s*|\s*$/g, '').replace(/\s+/g, ' ')
+			return str.replace(/^\s+|\s+$/g, '').replace(/\s+/g, ' ')
 		}
 
 		//util


### PR DESCRIPTION
1、在_toTemplateId()中进行参数检测，防止用户传入非字符串参数导致错误。
2、同时对startsWith()和endsWith()函数的实现方式进行修改。
3、对私有函数进行重命名
4、去除项目中bower.json以及单元测试中对underscore.string的依赖