### PR TITLE
添加单元测试并去除依赖

### DIFF
--- a/src/underscore-template.js
+++ b/src/underscore-template.js
@@ -153,6 +153,10 @@ var template = function () {
 
 	/** DEBUG_INFO_START **/
 	//exports for unit test
+	template.__trim = _trim
+	template.__include = _include
+	template.__startsWith = _startsWith
+	template.__endsWith = _endsWith
 	template.__toTemplateId = _toTemplateId
 	template.__toElementId = _toElementId
 	template.__isTemplateCode = _isTemplateCode

--- a/test/test.html
+++ b/test/test.html
@@ -16,7 +16,6 @@
 <!-- deps -->
 <script src="../bower_components/jquery/dist/jquery.js"></script>
 <script src="../bower_components/underscore/underscore.js"></script>
-<script src="../bower_components/underscore.string/lib/underscore.string.js"></script>
 <!-- testing framework -->
 <script src="../bower_components/mocha/mocha.js"></script>
 <script src="../bower_components/chai/chai.js"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,8 @@ void function () {
 	_.templateSettings.variable = 'data'
 
 	//const
+	var TEST_STR = 'This is test string'
+	var LONGER_STR = 'This substring is more longer'
 	var TEMPLATE_ID_1 = 'paragraph'
 	var TEMPLATE_ID_2 = 'person'
 	var HELLO = 'Hello world!'
@@ -36,18 +38,77 @@ void function () {
 	].join('\n')
 
 	describe('Util', function () {
+		var _trim
+		var _include
+		var _startsWith
+		var _endsWith
 		var _toTemplateId
 		var _toElementId
 		var _isTemplateCode
 		var _stripCommentTag
 
 		before(function () {
+			_trim = template.__trim
+			_include = template.__include
+			_startsWith = template.__startsWith
+			_endsWith = template.__endsWith
 			_toTemplateId = template.__toTemplateId
 			_toElementId = template.__toElementId
 			_isTemplateCode = template.__isTemplateCode
 			_stripCommentTag = template.__stripCommentTag
 		})
 
+		describe('_trim()', function () {
+			it('removes all `space` from the beginning and end of the supplied string', function () {
+				var arg
+				arg = '  foo bar  '
+				expect(_trim(arg)).to.equal('foo bar')
+				arg = '  foo bar'
+				expect(_trim(arg)).to.equal('foo bar')
+				arg = 'foo bar  '
+				expect(_trim(arg)).to.equal('foo bar')
+				arg = 'foo   bar'
+				expect(_trim(arg)).to.equal('foo   bar')
+				arg = ''
+				expect(_trim(arg)).to.equal('')
+			})
+		})
+		describe('_include()', function () {
+			it('return false when the length of subtring is shorter than supplied string', function () {
+				expect(_include(TEST_STR, LONGER_STR)).to.be.false
+			})
+			it('returns whether subtring is found within the supplied string', function () {
+				var arg
+				arg = 'test'
+				expect(_include(TEST_STR, arg)).to.be.true
+				arg = 'foobar'
+				expect(_include(TEST_STR, arg)).to.be.false
+			})
+		})
+		describe('_startsWith()', function () {
+			it('return false when the length of subtring is shorter than supplied string', function () {
+				expect(_startsWith(TEST_STR, LONGER_STR)).to.be.false
+			})
+			it('returns whether a string begins with the characters of another string', function () {
+				var arg
+				arg = 'This'
+				expect(_startsWith(TEST_STR, arg)).to.be.true
+				arg = 'foobar'
+				expect(_startsWith(TEST_STR, arg)).to.be.false
+			})
+		})
+		describe('_endsWith()', function () {
+			it('return false when the length of subtring is shorter than supplied string', function () {
+				expect(_endsWith(TEST_STR, LONGER_STR)).to.be.false
+			})
+			it('returns whether a string begins with the characters of another string', function () {
+				var arg
+				arg = 'string'
+				expect(_endsWith(TEST_STR, arg)).to.be.true
+				arg = 'foobar'
+				expect(_endsWith(TEST_STR, arg)).to.be.false
+			})
+		})
 		describe('_toTemplateId()', function () {
 			it('returns directly if initial character is not space, `#` or `!`', function () {
 				var arg

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ void function () {
 
 	//const
 	var TEST_STR = 'This is test string'
-	var LONGER_STR = 'This substring is more longer'
+	var LONGER_STR = 'This substring is longer than another'
 	var TEMPLATE_ID_1 = 'paragraph'
 	var TEMPLATE_ID_2 = 'person'
 	var HELLO = 'Hello world!'
@@ -59,7 +59,7 @@ void function () {
 		})
 
 		describe('_trim()', function () {
-			it('removes all `space` from the beginning and end of the supplied string', function () {
+			it('removes all spaces from the beginning and end of the supplied string', function () {
 				var arg
 				arg = '  foo bar  '
 				expect(_trim(arg)).to.equal('foo bar')
@@ -74,37 +74,49 @@ void function () {
 			})
 		})
 		describe('_include()', function () {
-			it('return false when the length of subtring is shorter than supplied string', function () {
+			it('returns false when the length of substring is shorter than supplied string', function () {
 				expect(_include(TEST_STR, LONGER_STR)).to.be.false
 			})
-			it('returns whether subtring is found within the supplied string', function () {
+			it('returns whether substring is found within the supplied string', function () {
 				var arg
 				arg = 'test'
 				expect(_include(TEST_STR, arg)).to.be.true
+				arg = 'st st'
+				expect(_include(TEST_STR, arg)).to.be.true
+				arg = 'test String'
+				expect(_include(TEST_STR, arg)).to.be.false
 				arg = 'foobar'
 				expect(_include(TEST_STR, arg)).to.be.false
 			})
 		})
 		describe('_startsWith()', function () {
-			it('return false when the length of subtring is shorter than supplied string', function () {
+			it('returns false when the length of substring is shorter than supplied string', function () {
 				expect(_startsWith(TEST_STR, LONGER_STR)).to.be.false
 			})
 			it('returns whether a string begins with the characters of another string', function () {
 				var arg
 				arg = 'This'
 				expect(_startsWith(TEST_STR, arg)).to.be.true
+				arg = 'this'
+				expect(_startsWith(TEST_STR, arg)).to.be.false
+				arg = 'This i'
+				expect(_startsWith(TEST_STR, arg)).to.be.true
 				arg = 'foobar'
 				expect(_startsWith(TEST_STR, arg)).to.be.false
 			})
 		})
 		describe('_endsWith()', function () {
-			it('return false when the length of subtring is shorter than supplied string', function () {
+			it('returns false when the length of substring is shorter than supplied string', function () {
 				expect(_endsWith(TEST_STR, LONGER_STR)).to.be.false
 			})
 			it('returns whether a string begins with the characters of another string', function () {
 				var arg
 				arg = 'string'
 				expect(_endsWith(TEST_STR, arg)).to.be.true
+				arg = 't string'
+				expect(_endsWith(TEST_STR, arg)).to.be.true
+				arg = 'est String'
+				expect(_endsWith(TEST_STR, arg)).to.false
 				arg = 'foobar'
 				expect(_endsWith(TEST_STR, arg)).to.be.false
 			})


### PR DESCRIPTION
1、去除test.html中对underscore.string的引用
2、添加_trim(),_include(),_startsWith(),_endsWith()函数的单元测试