### PR TITLE
修改_toTemplateId和_toElementId参数检测

### DIFF
--- a/src/underscore-template.js
+++ b/src/underscore-template.js
@@ -35,13 +35,13 @@ var template = function () {
 		//`#template-my-tpl-001` -> `my-tpl-001`
 		// `template-my-tpl-001` -> `my-tpl-001`
 		//          `my-tpl-001` -> `my-tpl-001`
-		id = _.isString(id) && id ? _trim(id).replace(/^[#!]+/, '') : ''
+		id = id && _.isString(id) ? _trim(id).replace(/^[#!]+/, '') : ''
 		return _trim(id).replace(ELEM_ID_PREFIX, '')
 	}
 	function _toElementId(id) {
 		//`template-my-tpl-001` -> `template-my-tpl-001`
 		//         `my-tpl-001` -> `template-my-tpl-001`
-		id = id ? _trim(id) : ''
+		id = id && _.isString(id) ? _trim(id) : ''
 		return _startsWith(id, ELEM_ID_PREFIX) ? id : ELEM_ID_PREFIX + id
 	}
 	function _stripCommentTag(str) {

--- a/test/test.js
+++ b/test/test.js
@@ -169,6 +169,15 @@ void function () {
 				arg = NaN
 				expect(_toTemplateId(arg)).to.equal('')
 			})
+			it('converts invalid type to empty string', function () {
+				var arg
+				arg = 1999
+				expect(_toTemplateId(arg)).to.equal('')
+				arg = {name: 'Peter', age: '20'}
+				expect(_toTemplateId(arg)).to.equal('')
+				arg = [1,2,3]
+				expect(_toTemplateId(arg)).to.equal('')
+			})
 		})
 		describe('_toElementId()', function () {
 			it('adds `' + PREFIX + '` prefix', function () {
@@ -192,6 +201,15 @@ void function () {
 				arg = false
 				expect(_toElementId(arg)).to.equal(PREFIX)
 				arg = NaN
+				expect(_toElementId(arg)).to.equal(PREFIX)
+			})
+			it('converts invalid type to `' + PREFIX + '`', function () {
+				var arg
+				arg = 1999
+				expect(_toElementId(arg)).to.equal(PREFIX)
+				arg = {name: 'Peter', age: '20'}
+				expect(_toElementId(arg)).to.equal(PREFIX)
+				arg = [1,2,3]
 				expect(_toElementId(arg)).to.equal(PREFIX)
 			})
 		})


### PR DESCRIPTION
1. 先检测参数是否存在，再检测类型
2. 补充单元测试中非字符串类型的测试
3. 单测通过